### PR TITLE
Add registration with custom required fields

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,60 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_filter :configure_sign_up_params, only: [:create]
+  # before_filter :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  def create
+    super
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def configure_sign_up_params
+    devise_parameter_sanitizer.for(:sign_up) << :birthday
+  end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.for(:account_update) << :attribute
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,16 +4,39 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
+  # add validations
+  before_validation :set_password
+  validates :birthday, presence: true
+
+  # if no validation, uncomment following line
+  # before_save :set_password
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.password = Devise.friendly_token[0, 20]
       user.nickname = auth.info.nickname
       user.sex = auth.info.sex
       user.avatar = auth.info.headimgurl
     end
   end
 
+  def self.new_with_session(params, session)
+    super.tap do |user|
+      if data = session['devise.wechat_data']
+        user.provider = data['provider']
+        user.uid = data['uid']
+        user.nickname = data['info']['nickname']
+        user.sex = data['info']['sex']
+        user.avatar = data['info']['headimgurl']
+      end
+    end
+  end
+
   def email_required?
     false
+  end
+
+  private
+  def set_password
+    self.password = Devise.friendly_token[0, 20]
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,26 @@
+<script src="http://res.wx.qq.com/open/js/jweixin-1.0.0.js"></script>
+<%= wechat_config_js debug: false, api: %w(closeWindow) -%>
+
+<div class="weui_msg">
+  <div class="weui_text_area">
+    <h1 class="weui_msg_title">Sign Up</h1>
+  </div>
+</div>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <div class="weui_cells_title">Following fields is required</div>
+  <div class="weui_cells weui_cells_form">
+    <div class="weui_cell">
+      <div class="weui_cell_hd">
+        <%= f.label :birthday, class: 'weui_label' %>
+      </div>
+      <div class="weui_cell_bd weui_cell_primary">
+        <%= f.date_field :birthday, class: 'weui_input' %>
+      </div>
+    </div>
+  </div>
+  <div class="weui_btn_area">
+    <%= f.submit "Confirm", class: 'weui_btn weui_btn_primary' %>
+    <a href="javascript:wx.closeWindow();" class="weui_btn weui_btn_plain_default">Close</a>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   post 'wx_pay' => 'home#wx_pay'
   post 'wx_notify' => 'home#wx_notify'
   root to: 'home#index'
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   resource :wechat, only: [:show, :create]
+  devise_for :users, controllers: {
+               omniauth_callbacks: 'users/omniauth_callbacks',
+               registrations: 'users/registrations'
+             }
 end

--- a/db/migrate/20160224054132_add_birthday_to_users.rb
+++ b/db/migrate/20160224054132_add_birthday_to_users.rb
@@ -1,0 +1,5 @@
+class AddBirthdayToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :birthday, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160223133841) do
+ActiveRecord::Schema.define(version: 20160224054132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20160223133841) do
     t.string   "nickname"
     t.integer  "sex"
     t.string   "avatar"
+    t.datetime "birthday"
   end
 
   add_index "users", ["nickname"], name: "index_users_on_nickname", unique: true, using: :btree


### PR DESCRIPTION
If the app requires extra `User` fields like _address_ or _age_,  users should be redirect to the registration page after receive the oauth2 callback.